### PR TITLE
Integrate ui with autoconfig and obfuscate

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -36,6 +36,20 @@
     public static *** i(...);
 }
 
+# Strip custom Logs in release
+-assumenosideeffects class io.nekohasekai.sagernet.ktx.Logs {
+    public static void d(java.lang.String);
+    public static void d(java.lang.String, java.lang.Throwable);
+    public static void i(java.lang.String);
+    public static void i(java.lang.String, java.lang.Throwable);
+    public static void w(java.lang.String);
+    public static void w(java.lang.String, java.lang.Throwable);
+    public static void w(java.lang.Throwable);
+    public static void e(java.lang.String);
+    public static void e(java.lang.String, java.lang.Throwable);
+    public static void e(java.lang.Throwable);
+}
+
 # ini4j
 -keep public class org.ini4j.spi.** { <init>(); }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/Constants.kt
@@ -149,6 +149,7 @@ object Key {
 
     const val APP_TLS_VERSION = "appTLSVersion"
     const val ENABLE_CLASH_API = "enableClashAPI"
+    const val UDP_FRAGMENT = "udpFragment"
 }
 
 object TunImplementation {

--- a/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/database/DataStore.kt
@@ -162,6 +162,7 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     // protocol
 
     var globalAllowInsecure by configurationStore.boolean(Key.GLOBAL_ALLOW_INSECURE) { false }
+    var udpFragment by configurationStore.boolean(Key.UDP_FRAGMENT)
 
     // old cache, DO NOT ADD
 

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -239,6 +239,7 @@ fun buildConfig(
                 domain_strategy = genDomainStrategy(DataStore.resolveDestination)
                 sniff = needSniff
                 sniff_override_destination = needSniffOverride
+                udp_fragment = DataStore.udpFragment
             })
         }
 
@@ -386,6 +387,7 @@ fun buildConfig(
                                 currentOutbound["multiplex"] = muxObj.asMap()
                             }
                         }
+                        currentOutbound["udp_fragment"] = DataStore.udpFragment
                     }
                 }
 
@@ -444,25 +446,26 @@ fun buildConfig(
                         bean.finalAddress = LOCALHOST
                         bean.finalPort = mappingPort
 
-                        inbounds.add(Inbound_DirectOptions().apply {
-                            type = "direct"
-                            listen = LOCALHOST
-                            listen_port = mappingPort
-                            tag = "$chainTag-mapping-${proxyEntity.id}"
+                                        inbounds.add(Inbound_DirectOptions().apply {
+                    type = "direct"
+                    listen = LOCALHOST
+                    listen_port = mappingPort
+                    tag = "$chainTag-mapping-${proxyEntity.id}"
+                    udp_fragment = DataStore.udpFragment
 
-                            override_address = bean.serverAddress
-                            override_port = bean.serverPort
+                    override_address = bean.serverAddress
+                    override_port = bean.serverPort
 
-                            pastInboundTag = tag
+                    pastInboundTag = tag
 
-                            // no chain rule and not outbound, so need to set to direct
-                            if (index == profileList.lastIndex) {
-                                route.rules.add(Rule_DefaultOptions().apply {
-                                    inbound = listOf(tag)
-                                    outbound = TAG_DIRECT
-                                })
-                            }
+                    // no chain rule and not outbound, so need to set to direct
+                    if (index == profileList.lastIndex) {
+                        route.rules.add(Rule_DefaultOptions().apply {
+                            inbound = listOf(tag)
+                            outbound = TAG_DIRECT
                         })
+                    }
+                })
                     }
                 }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/ConfigurationFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/ConfigurationFragment.kt
@@ -115,6 +115,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.ZipInputStream
 import kotlin.collections.set
+import moe.matsuri.nb4a.AutoConfigImporter
 
 class ConfigurationFragment @JvmOverloads constructor(
     val select: Boolean = false, val selectedItem: ProxyEntity? = null, val titleRes: Int = 0
@@ -589,6 +590,16 @@ class ConfigurationFragment @JvmOverloads constructor(
 
             R.id.action_connection_url_test -> {
                 urlTest()
+            }
+            R.id.action_auto_import -> {
+                runOnLifecycleDispatcher {
+                    val importer = AutoConfigImporter(requireContext())
+                    importer.manualImport()
+                }
+            }
+            R.id.action_cleanup_bad_configs -> {
+                val importer = AutoConfigImporter(requireContext())
+                importer.cleanupBadConfigs()
             }
         }
         return true

--- a/app/src/main/res/menu/add_profile_menu.xml
+++ b/app/src/main/res/menu/add_profile_menu.xml
@@ -75,6 +75,12 @@
         app:showAsAction="always">
         <menu>
             <item
+                android:id="@+id/action_auto_import"
+                android:title="@string/auto_import_configs" />
+            <item
+                android:id="@+id/action_cleanup_bad_configs"
+                android:title="@string/cleanup_bad_configs" />
+            <item
                 android:id="@+id/action_update_subscription"
                 android:title="@string/update_current_subscription" />
             <item

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -434,6 +434,9 @@
     <string name="warp_generate">ایجاد پیکربندی</string>
     <string name="generating">در حال ایجاد...</string>
     <string name="tun_implementation">پیاده‌سازی TUN</string>
+    <string name="auto_import_configs">دریافت خودکار کانفیگ</string>
+    <string name="cleanup_bad_configs">حذف کانفیگ‌های خراب</string>
+    <string name="udp_fragment">تکه‌تکه‌سازی UDP</string>
     <string name="destination_override">بازنویسی مقصد</string>
     <string name="destination_override_summary">از دامنه ردیابی‌شده برای بازنویسی آدرس مقصد استفاده کنید، نه فقط برای مسیریابی.</string>
     <string name="resolve_destination">بررسی مقصد</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,4 +566,7 @@
     <string name="padding">Padding</string>
     <string name="network_change_reset_connections">Reset outbound connections when network changes</string>
     <string name="wake_reset_connections">Reset outbound connections when device wake from sleep</string>
+    <string name="auto_import_configs">Auto import configs</string>
+    <string name="cleanup_bad_configs">Cleanup bad configs</string>
+    <string name="udp_fragment">UDP Fragment</string>
 </resources>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -239,5 +239,8 @@
         <SwitchPreference
             app:key="showBottomBar"
             app:title="@string/show_bottom_bar" />
+        <SwitchPreference
+            app:key="udpFragment"
+            app:title="@string/udp_fragment" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Add UI for AutoConfigImporter and UDP Fragment setting, and apply additional ProGuard obfuscation to optimize, secure, and add new capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-8356ea9c-f111-446c-9f32-4f4422c9bb00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8356ea9c-f111-446c-9f32-4f4422c9bb00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

